### PR TITLE
Fix: Show "See More" button only if there are any upcoming contents

### DIFF
--- a/Open Judge System/Web/OJS.Web/Views/Home/Index.cshtml
+++ b/Open Judge System/Web/OJS.Web/Views/Home/Index.cshtml
@@ -112,8 +112,8 @@
                     </tr>
                 }
             </table>
+            <p class="pull-right"><a class="btn btn-default" href="/Contests/">@Resource.See_more &raquo;</a></p>
         }
-        <p class="pull-right"><a class="btn btn-default" href="/Contests/">@Resource.See_more &raquo;</a></p>
         @if (User.IsAdmin())
         {
             <p class="pull-left"><a class="btn btn-primary" href="/Administration/Contests">@Resource.Administration &raquo;</a></p>


### PR DESCRIPTION
Putted html for "See More" button in the if, which checks for any upcoming events. Other "See More" buttons are not necessary to check, since there will always be a past event and a past news post