### PR TITLE
Fixed test in RestrictedProcess

### DIFF
--- a/Open Judge System/Tests/OJS.Workers.Executors.Tests/RestrictedProcessSecurityTests.cs
+++ b/Open Judge System/Tests/OJS.Workers.Executors.Tests/RestrictedProcessSecurityTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace OJS.Workers.Executors.Tests
 {
+    using System;
     using System.Diagnostics;
     using System.Linq;
     using System.Windows.Forms;
@@ -33,6 +34,7 @@ class Program
         }
 
         [Test]
+        [STAThread]
         public void RestrictedProcessShouldNotBeAbleToReadClipboard()
         {
             const string ReadClipboardSourceCode = @"using System;


### PR DESCRIPTION
Fixed test for RestrictedProcess not to be able to read clipboard by adding a STAThread attribute.